### PR TITLE
NMPC class API change

### DIFF
--- a/src/control/nmpc.hpp
+++ b/src/control/nmpc.hpp
@@ -4,17 +4,13 @@
 #include "control/cost_collocation.hpp"
 #include "control/ode_collocation.hpp"
 #include "control/problem.hpp"
-#include "solvers/sqp.hpp"
 
 namespace polympc {
 
-template<typename Problem, typename Approximation, typename Solver>
+template<typename Problem, typename Approximation, template <typename> class Solver>
 class nmpc
 {
 public:
-    nmpc(){}
-    ~nmpc(){}
-
     using Scalar     = typename Problem::Dynamics::Scalar;
     using State      = typename Problem::Dynamics::State;
     using Control    = typename Problem::Dynamics::Control;
@@ -23,6 +19,7 @@ public:
     using ode_colloc_t = ode_collocation<typename Problem::Dynamics, Approximation, 2>;
     using cost_colloc_t = cost_collocation<typename Problem::Lagrange, typename Problem::Mayer, Approximation, 2>;
     using var_t = typename cost_colloc_t::var_t;
+    using SolverImpl = Solver<nmpc>;
 
     enum
     {
@@ -36,136 +33,187 @@ public:
 
         NUM_EQ = VARX_SIZE,
         NUM_INEQ = 0,
+        NUM_CONSTR = NUM_EQ+NUM_INEQ+VAR_SIZE,
     };
 
     using ode_jacobian_t = typename ode_colloc_t::jacobian_t;
     using cost_gradient_t = var_t;
     using varx_t = typename Eigen::Matrix<Scalar, VARX_SIZE, 1>;
     using varu_t = typename Eigen::Matrix<Scalar, VARU_SIZE, 1>;
-
-    using sqp_t = sqp::SQP<nmpc>;
-    using dual_t = typename sqp_t::dual_t;
+    using dual_t = Eigen::Matrix<Scalar, NUM_CONSTR, 1>;
 
     using eq_t = Eigen::Matrix<Scalar, NUM_EQ, 1>;
     using A_eq_t = Eigen::Matrix<Scalar, NUM_EQ, VAR_SIZE>;
     using ineq_t = Eigen::Matrix<Scalar, NUM_INEQ, 1>;
     using A_ineq_t = Eigen::Matrix<Scalar, NUM_INEQ, VAR_SIZE>;
 
-    cost_colloc_t cost_f;
-    ode_colloc_t ps_ode;
-    sqp_t solver;
+    cost_colloc_t m_cost_f;
+    ode_colloc_t m_ps_ode;
 
-    State _x0;
-    Parameters _p0;
-    State _constr_xl, _constr_xu;
-    Control _constr_ul, _constr_uu;
+    State m_x0;
+    Parameters m_p0;
+    State m_bound_xl, m_bound_xu;
+    Control m_bound_ul, m_bound_uu;
 
+    var_t m_solution;
+    dual_t m_dual_solution;
+
+    bool m_warm_start;
+    SolverImpl m_solver;
+    Problem m_problem;
+
+public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    /*
-     * var_t var = [xn, ..., x0, un, ..., u0, p]
-     *
-     * constraints:
-     * xl < x < xu
-     * ul < u < uu
-     * x0 = x(t0)
-     * ps_ode(X) = 0
-     */
+    nmpc(){}
+    ~nmpc(){}
 
-    void cost(const var_t& var, Scalar &cst)
+    void enableWarmStart() {m_warm_start = true;}
+    void disableWarmStart() {m_warm_start = false;}
+    void computeControl(const State& x0);
+
+    void getOptimalControl(Control& u)
     {
-        cost_f(var, cst);
+        varGetControl(m_solution, 0, u);
     }
 
-    void cost_linearized(const var_t& var, cost_gradient_t &grad, Scalar &cst)
+    void getSolution(var_t& var)
     {
-        cost_f.value_gradient(var, cst, grad);
+        var = m_solution;
     }
 
-    void constraint(const var_t& var, eq_t& b_eq, ineq_t& b_ineq, var_t& lbx, var_t& ubx) {
-        varx_t c_ode;
-        ps_ode(var, c_ode);
-        set_constraints(var, c_ode, b_eq, b_ineq, lbx, ubx);
+    void varGetControl(const var_t& var, int i, Control& u) const
+    {
+        u = var.template segment<NU>(VARX_SIZE+VARU_SIZE-NU-NU*i);
     }
 
-    void set_constraints(const var_t& var, const varx_t& c_ode, eq_t& eq, ineq_t& ineq, var_t& lbx, var_t& ubx)
+    void varGetState(const var_t& var, int i, State& x) const
     {
-        (void) ineq; // unused
-        eq << c_ode;
-        lbx << _constr_xl.template replicate<VARX_SIZE/NX-1, 1>(),
-               _x0,
-               _constr_ul.template replicate<VARU_SIZE/NU, 1>(),
-               _p0;
-        ubx << _constr_xu.template replicate<VARX_SIZE/NX-1, 1>(),
-               _x0,
-               _constr_uu.template replicate<VARU_SIZE/NU, 1>(),
-               _p0;
+        x = var.template segment<NX>(VARX_SIZE-NX-NX*i);
     }
 
-    void constraint_linearized(const var_t& var,
-                               A_eq_t& A_eq,
-                               eq_t& eq,
-                               A_ineq_t& A_ineq,
-                               ineq_t& ineq,
-                               var_t& lbx,
-                               var_t& ubx)
+    void varGetParam(const var_t& var, Parameters& p) const
     {
-        // TODO: avoid stack allocation
-        varx_t c_ode;
-        ode_jacobian_t ode_jac;
-
-        ps_ode.linearized(var, ode_jac, c_ode);
-        set_constraints(var, c_ode, eq, ineq, lbx, ubx);
-
-        A_eq.setZero();
-        A_eq.template topRows<VARX_SIZE>() = ode_jac;
+        p = var.template segment<NP>(VARX_SIZE+VARU_SIZE);
     }
 
-    void set_constraints(const State& xl, const State& xu, const Control& ul, const Control& uu)
+    void setStateBounds(const State& xl, const State& xu)
     {
-        _constr_xl = xl;
-        _constr_xu = xu;
-        _constr_ul = ul;
-        _constr_uu = uu;
+        m_bound_xl = xl;
+        m_bound_xu = xu;
     }
 
-    var_t solve(const State& x0, const Parameters& p0)
+    void setControlBounds(const Control& ul, const Control& uu)
     {
-        _x0 = x0;
-        _p0 = p0;
+        m_bound_ul = ul;
+        m_bound_uu = uu;
+    }
 
-        var_t var0;
+    void setParameters(const Parameters& param)
+    {
+        m_p0 = param;
+    }
+
+    // required by solver
+    void cost(const var_t& var, Scalar &cst);
+    void cost_linearized(const var_t& var, cost_gradient_t &grad, Scalar &cst);
+    void constraint(const var_t& var, eq_t& b_eq, ineq_t& b_ineq, var_t& lbx, var_t& ubx);
+    void _set_constraints(const var_t& var, const varx_t& c_ode, eq_t& eq, ineq_t& ineq, var_t& lbx, var_t& ubx);
+    void constraint_linearized(const var_t& var, A_eq_t& A_eq, eq_t& eq, A_ineq_t& A_ineq, ineq_t& ineq, var_t& lbx, var_t& ubx);
+};
+
+template<typename Problem, typename Approximation, template <typename> class Solver>
+void nmpc<Problem, Approximation, Solver>
+::computeControl(const State& x0)
+{
+    m_x0 = x0;
+
+    var_t& var0 = m_solution;
+    dual_t& dual0 = m_dual_solution;
+
+    if (m_warm_start) {
+        var0.template segment<NX>(VARX_SIZE-NX) = x0;
+    } else {
         var0.setZero();
         var0.template segment<VARX_SIZE>(0) = x0.template replicate<VARX_SIZE/NX, 1>();
-        var0.template segment<1>(VARX_SIZE+VARU_SIZE) = _p0;
+        var0.template segment<1>(VARX_SIZE+VARU_SIZE) = m_p0;
 
-        dual_t y0;
-        y0.setZero();
-
-        solver.settings().max_iter = 100;
-        solver.settings().line_search_max_iter = 3;
-
-        solver.solve(*this, var0, y0);
-
-        return solver.primal_solution();
+        dual0.setZero();
     }
 
-    var_t solve_warm_start(const State& x0, const Parameters& p0)
-    {
-        _x0 = x0;
-        _p0 = p0;
+    m_solver.settings().max_iter = 100;
+    m_solver.settings().line_search_max_iter = 3;
+    m_solver.solve(*this, var0, dual0);
 
-        var_t var0 = solver.primal_solution();
-        dual_t y0 = solver.dual_solution();
+    m_solution = m_solver.primal_solution();
+    m_dual_solution = m_solver.dual_solution();
 
-        var0.template segment<NX>(VARX_SIZE-NX) = x0;
-
-        solver.solve(*this, var0, y0);
-        return solver.primal_solution();
-    }
-};
+    // TODO: return status?
 }
 
+template<typename Problem, typename Approximation, template <typename> class Solver>
+void nmpc<Problem, Approximation, Solver>
+::cost(const var_t& var, Scalar &cst)
+{
+    m_cost_f(var, cst);
+}
 
+template<typename Problem, typename Approximation, template <typename> class Solver>
+void nmpc<Problem, Approximation, Solver>
+::cost_linearized(const var_t& var, cost_gradient_t &grad, Scalar &cst)
+{
+    m_cost_f.value_gradient(var, cst, grad);
+}
+
+template<typename Problem, typename Approximation, template <typename> class Solver>
+void nmpc<Problem, Approximation, Solver>
+::constraint(const var_t& var, eq_t& b_eq, ineq_t& b_ineq, var_t& lbx, var_t& ubx)
+{
+    varx_t c_ode;
+    m_ps_ode(var, c_ode);
+    _set_constraints(var, c_ode, b_eq, b_ineq, lbx, ubx);
+}
+
+/*
+ * var_t var = [xn, ..., x0, un, ..., u0, p]
+ *
+ * constraints:
+ * xl < x < xu
+ * ul < u < uu
+ * x0 = x(t0)
+ * ps_ode(X) = 0
+ */
+template<typename Problem, typename Approximation, template <typename> class Solver>
+void nmpc<Problem, Approximation, Solver>
+::_set_constraints(const var_t& var, const varx_t& c_ode, eq_t& eq, ineq_t& ineq, var_t& lbx, var_t& ubx)
+{
+    (void) ineq; // unused
+    eq << c_ode;
+    lbx << m_bound_xl.template replicate<VARX_SIZE/NX-1, 1>(),
+           m_x0,
+           m_bound_ul.template replicate<VARU_SIZE/NU, 1>(),
+           m_p0;
+    ubx << m_bound_xu.template replicate<VARX_SIZE/NX-1, 1>(),
+           m_x0,
+           m_bound_uu.template replicate<VARU_SIZE/NU, 1>(),
+           m_p0;
+}
+
+template<typename Problem, typename Approximation, template <typename> class Solver>
+void nmpc<Problem, Approximation, Solver>
+::constraint_linearized(const var_t& var,
+                           A_eq_t& A_eq,
+                           eq_t& eq,
+                           A_ineq_t& A_ineq,
+                           ineq_t& ineq,
+                           var_t& lbx,
+                           var_t& ubx)
+{
+    varx_t c_ode;
+    m_ps_ode.linearized(var, A_eq, c_ode);
+    _set_constraints(var, c_ode, eq, ineq, lbx, ubx);
+}
+
+}
 
 #endif // NMPC_HPP

--- a/src/control/problem.hpp
+++ b/src/control/problem.hpp
@@ -7,25 +7,16 @@
 /** class to store Optimal Control problems */
 namespace polympc {
 
-struct EmptyFunctor
-{
-    EmptyFunctor(){}
-    ~EmptyFunctor(){}
-};
-
-
-template<typename _Dynamics, typename _Lagrange, typename _Mayer, typename _InequalityConstraints = EmptyFunctor, typename _EqualityConstraints = EmptyFunctor>
+template<typename _Dynamics, typename _Lagrange, typename _Mayer>
 class OCProblem
 {
 public:
-    OCProblem();
+    OCProblem(){};
     ~OCProblem(){}
 
     using Dynamics = _Dynamics;
     using Lagrange = _Lagrange;
     using Mayer    = _Mayer;
-    using InequalityConstraints = _InequalityConstraints;
-    using EqualityConstraints = _EqualityConstraints;
 
     enum
     {
@@ -33,19 +24,7 @@ public:
         NU_D = Dynamics::Control::RowsAtCompileTime,
         NP_D = Dynamics::Parameters::RowsAtCompileTime,
     };
-
-    Dynamics m_f;
-    Lagrange m_lagrange;
-    Mayer    m_mayer;
-    EqualityConstraints m_eq_h;
-    InequalityConstraints m_ineq_g;
 };
-
-template<typename Dynamics, typename Lagrange, typename Mayer, typename InequalityConstraints, typename EqualityConstraints>
-OCProblem<Dynamics, Lagrange, Mayer, InequalityConstraints, EqualityConstraints>::OCProblem()
-{
-}
-
 
 }
 


### PR DESCRIPTION
This PR makes the nmpc class API more structured.
For example, it allows selecting the solver by a template argument.

It is inspired by the existing [nmpc.hpp](https://github.com/LA-EPFL/polympc/blob/e5eefd14b101d660f4b011f63afe00a1b68afea7/src/nmpc.hpp).